### PR TITLE
Two more propositions on how to deal with 3rd party extension (no direct editions and what to do in case of a rewrite conflict)

### DIFF
--- a/_posts/03-02-01-ThirdPartyExtensions.md
+++ b/_posts/03-02-01-ThirdPartyExtensions.md
@@ -5,4 +5,6 @@ isChild: true
 ---
 
 * Perform a code review of any extension you install on a client site.
+* Don't edit any 3rd party extension directly, because your changes may be lost when the extension is updated. Instead, create your own local module that depends on the one you want to edit and that either rewrites its models/blocks or uses events to achieve the desired effect.
+* Check if the extension you are about to install doesn't rewrite any models or blocks already rewritten by other extensions on your Magento instance. If it does, you are facing a rewrite conflict and you need to make your own local module that depends on both modules (so it's loaded after them) and rewrites the same models/blocks in a way that won't prevent any of conflicting modules from working correctly.
 * Build a list of trusted (and untrusted) extension providers.


### PR DESCRIPTION
Two more propositions on how to deal with 3rd party extension: 
- no direct editions (because such changes may be lost when the extension is updated) 
- what to do in case of a rewrite conflict (when two or more modules rewrite the same blocks/models, only the one parsed last will be working correctly - in this case it's necessary to create a local module that <code>depends</code> on every conflicting module (so it's loaded last) and rewrites the same things (so a developer can ensure that it includes all the pieces of code needed for conflicting modules to work correctly). A good practice is to <code>extend</code> the final models/blocks using one of conflicting classes, so its code doesn't have to be repeated (this approach won't work if conflicting modules make changes to the same class methods). This piece of advice is not included in the commit, because it would make the text a bit too long - I think we don't want to transform the magentotherightway.com into a 300-pages rule book just now. ;-)
